### PR TITLE
TECH-2: shared renovate config repo

### DIFF
--- a/modules/live/repos.tf
+++ b/modules/live/repos.tf
@@ -37,3 +37,11 @@ module "hello-twilio" {
   description    = "Twilio function POC"
   prod_reviewers = local.prod_reviewers
 }
+
+module "renovate-config" {
+  source         = "../repo"
+  name           = "renovate-config"
+  visibility     = "public"
+  description    = "Shared renovate configurations"
+  prod_reviewers = local.prod_reviewers
+}

--- a/modules/live/ruleset.tf
+++ b/modules/live/ruleset.tf
@@ -1,28 +1,30 @@
 # This mirrors our branch protection rules.
 # But we can't use Rulesets until we buy GitHub Teams.
 # So this is disabled (see count=0 below).
-resource "github_repository_ruleset" "main" {
+resource "github_repository_ruleset" "main_and_version_branches" {
 
   # API gives 403 until we buy GitHub Teams
   count = 0
 
-  name        = "main"
+  name        = "main + v* branches"
   target      = "branch"
   enforcement = "active"
 
   conditions {
     ref_name {
-      include = ["main"]
+      include = [
+        "refs/heads/main",
+        "refs/heads/v*"
+      ]
       exclude = []
     }
   }
 
   rules {
-    # Match your intent:
-    creation                = false # don't restrict creating the branch
-    update                  = false # don't lock the branch
-    deletion                = true  # block deletions
-    non_fast_forward        = true  # block force-pushes
+    creation                = false # allow creating new branches
+    update                  = false # allow normal pushes
+    deletion                = true  # block branch deletion
+    non_fast_forward        = true  # block force pushes
     required_linear_history = false
     required_signatures     = false
 
@@ -34,12 +36,11 @@ resource "github_repository_ruleset" "main" {
       require_last_push_approval        = false
       required_review_thread_resolution = false
     }
-
   }
 
   bypass_actors {
     actor_type  = "OrganizationAdmin"
-    actor_id    = 1     # constant meaning "all org admins"
+    actor_id    = 1 # constant meaning "all org admins"
     bypass_mode = "pull_request"
   }
 }
@@ -64,21 +65,21 @@ resource "github_repository_ruleset" "version_tags" {
   rules {
     # Creation allowed; flip to true to forbid creating new v* tags
     creation         = false
-    update           = true   # block moving (retagging)
-    deletion         = true   # block deleting tags
+    update           = true # block moving (retagging)
+    deletion         = true # block deleting tags
     non_fast_forward = true
 
     # loose SemVer (vMAJOR or vMAJOR.MINOR or vMAJOR.MINOR.PATCH)
     tag_name_pattern {
       operator = "regex"
       # v1  or  v1.2  or  v1.2.3
-      pattern  = "^v\\d+(?:\\.\\d+){0,2}$"
+      pattern = "^v\\d+(?:\\.\\d+){0,2}$"
     }
   }
 
   bypass_actors {
     actor_type  = "OrganizationAdmin"
-    actor_id    = 1     # constant meaning "all org admins"
+    actor_id    = 1 # constant meaning "all org admins"
     bypass_mode = "pull_request"
   }
 }

--- a/modules/repo/.terraform.lock.hcl
+++ b/modules/repo/.terraform.lock.hcl
@@ -1,7 +1,7 @@
-# This file is maintained automatically by "terraform init".
+# This file is maintained automatically by "tofu init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/integrations/github" {
+provider "registry.opentofu.org/integrations/github" {
   version     = "6.6.0"
   constraints = "6.6.0"
   hashes = [

--- a/modules/repo/branch_protection.tf
+++ b/modules/repo/branch_protection.tf
@@ -49,3 +49,9 @@ resource "github_branch_protection" "main" {
 
   require_signed_commits = false
 }
+
+// Protect version tags
+resource "github_repository_tag_protection" "version_tags" {
+  repository = github_repository.this.name
+  pattern    = "v*"
+}

--- a/modules/repo/branch_protection.tf
+++ b/modules/repo/branch_protection.tf
@@ -2,16 +2,17 @@ locals {
   super_admins = [
     "michaelknopf"
   ]
+  branch_patterns = var.visibility == "public" ? [local.main_branch, "v*"] : []
 }
 
 # Protect main branch by default
 resource "github_branch_protection" "main" {
 
   # Private repos cannot use branch protection rules until we upgrade to GitHub Teams.
-  count = var.visibility == "public" ? 1 : 0
+  for_each = toset(local.branch_patterns)
 
   repository_id = github_repository.this.node_id
-  pattern       = local.main_branch
+  pattern       = each.value
 
   # require status checks even for repo admins
   enforce_admins = true
@@ -48,10 +49,4 @@ resource "github_branch_protection" "main" {
   allows_force_pushes = false
 
   require_signed_commits = false
-}
-
-// Protect version tags
-resource "github_repository_tag_protection" "version_tags" {
-  repository = github_repository.this.name
-  pattern    = "v*"
 }

--- a/root.hcl
+++ b/root.hcl
@@ -40,7 +40,7 @@ generate "versions" {
       required_providers {
         github = {
           source  = "integrations/github",
-          version = ">= 6.0"
+          version = ">= 6.6.0"
         }
         tls  = {
           source = "hashicorp/tls",


### PR DESCRIPTION
Create repo for shared renovate configs. Also, create more branch/tag protection rules, to prepare for branch-based versioning approach that this repo will use.